### PR TITLE
Fix 'sidebarModel.hide is not a function' error

### DIFF
--- a/view/frontend/web/js/view/shipping-information.js
+++ b/view/frontend/web/js/view/shipping-information.js
@@ -4,7 +4,6 @@ define([
     'uiComponent',
     'Magento_Checkout/js/model/quote',
     'Magento_Checkout/js/model/step-navigator',
-    'mage/translate',
     'Magento_Checkout/js/model/sidebar'
 ], function ($, Component, quote, stepNavigator, sidebarModel) {
     'use strict';


### PR DESCRIPTION
```
define([
    'jquery',
    'uiComponent',
    'Magento_Checkout/js/model/quote',
    'Magento_Checkout/js/model/step-navigator',
    'mage/translate',
    'Magento_Checkout/js/model/sidebar'
], function ($, Component, quote, stepNavigator, sidebarModel) {
```
unused 'mage/translate' added to define, but not to function, causes mage/translate being mapped to sidebarModel, which makes the subsequent calls to sidebarModel.hide in the back and backToShippingMethod functions actually call 'mage/translate'.hide, which is not a function.