### PR TITLE
Use TimezoneInterface to format date according to locale, translations

### DIFF
--- a/Plugin/Checkout/LayoutProcessorPlugin.php
+++ b/Plugin/Checkout/LayoutProcessorPlugin.php
@@ -4,6 +4,7 @@ namespace Trunkrs\Carrier\Plugin\Checkout;
 
 use GuzzleHttp\Client;
 use Magento\Checkout\Block\Checkout\LayoutProcessor;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Trunkrs\Carrier\Helper\Data;
 use Trunkrs\Carrier\Model\Carrier\Shipping;
 
@@ -11,11 +12,15 @@ class LayoutProcessorPlugin
 {
     protected $trunkrsObj;
 
+    protected $timezone;
+
     public function __construct(
-        Shipping $trunkrsObj
+        Shipping $trunkrsObj,
+        TimezoneInterface $timezone
     )
     {
         $this->trunkrsObj = $trunkrsObj;
+        $this->timezone = $timezone;
     }
 
     /**
@@ -50,7 +55,7 @@ class LayoutProcessorPlugin
             foreach($response as $delivery) {
                 $options[] = [
                     'value' => Data::parse8601($delivery->deliveryDate)->format('Y-m-d'),
-                    'label' => date("l j, F", Data::parse8601($delivery->announceBefore)->getTimestamp())
+                    'label' => $this->timezone->formatDate(Data::parse8601($delivery->announceBefore), \IntlDateFormatter::FULL, false),
                 ];
             }
         }

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,3 +1,4 @@
 "Select delivery date:","Select delivery date:"
 edit,edit
+"Delivery date:","Delivery date:"
 

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,6 +1,3 @@
-Trunkrs Shipping, Trunkrs Shipping
-Version, Version
-Price, Price
-Test Mode, Test Mode
-Delivery Time, Delivery Time
-Trunkrs API Token, Trunkrs API Token
+"Select delivery date:","Select delivery date:"
+edit,edit
+

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -1,0 +1,3 @@
+"Select delivery date:","Selecteer bezorgdatum:"
+edit,bewerken
+

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -1,3 +1,4 @@
 "Select delivery date:","Selecteer bezorgdatum:"
 edit,bewerken
+"Delivery date:","Bezorgdatum:"
 

--- a/view/frontend/web/js/view/shipping-information.js
+++ b/view/frontend/web/js/view/shipping-information.js
@@ -4,8 +4,9 @@ define([
     'Magento_Checkout/js/model/quote',
     'Magento_Checkout/js/model/step-navigator',
     'Magento_Checkout/js/model/sidebar',
-    'Magento_Catalog/js/price-utils'
-], function ($, Component, quote, stepNavigator, sidebarModel, priceUtils) {
+    'Magento_Catalog/js/price-utils',
+    'mage/translate'
+], function ($, Component, quote, stepNavigator, sidebarModel, priceUtils, $t) {
     'use strict';
 
     return Component.extend({
@@ -36,7 +37,7 @@ define([
             var shippingMethod = quote.shippingMethod().method_code+'_'+quote.shippingMethod().carrier_code;
             var selectedTimeslot = jQuery('[name="trunkrs_shipping_field[trunkrs_delivery_date]"] option:selected').text();
             if(shippingMethod === "trunkrsShipping_trunkrsShipping") {
-                return 'Delivery date: ' + selectedTimeslot;
+                return $t('Delivery date:') + ' ' + selectedTimeslot;
             }
             return '';
         },


### PR DESCRIPTION
Dates in select in checkout are not translated to the stores locale. Use TimezoneInterface to properly format dates according to the selected stores locale. Also added a Dutch translation for the 'Select delivery date:' string:
![Schermafbeelding 2022-06-22 om 11 00 58](https://user-images.githubusercontent.com/16759472/174989399-44696c4e-693c-49c6-951b-fd458ae838e4.png)

