### PR TITLE
Add empty default value for integration details

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,7 +5,8 @@
         <carriers>
             <trunkrsShipping>
                 <model>Trunkrs\Carrier\Model\Carrier\Shipping</model>
-            </trunkrsShipping>
+	        <integration_details>{}</integration_details>
+	    </trunkrsShipping>
         </carriers>
     </default>
 </config>


### PR DESCRIPTION
This prevents the error of json_decode function getting null as parameter.