### PR TITLE
Hotfix: add empty label catch

### DIFF
--- a/Controller/Adminhtml/Order/PrintLabelAndPackingSlips.php
+++ b/Controller/Adminhtml/Order/PrintLabelAndPackingSlips.php
@@ -124,9 +124,9 @@ class PrintLabelAndPackingSlips extends LabelAbstract
             }
         }
 
-        if (empty($this->orderIds)) {
+        if (empty($this->orderIds) || empty($this->labels)) {
             $this->messageManager->addErrorMessage(
-                __('No pdf generated. Trunkrs shipment not found.')
+                __('No document generated. Trunkrs shipment not found.')
             );
             return $this->_redirect($this->_redirect->getRefererUrl());
         }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "trunkrs magento 2 shipping method"
   ],
   "type": "magento2-module",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": [
     "MIT"
   ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Trunkrs_Carrier" setup_version="2.3.0">
+    <module name="Trunkrs_Carrier" setup_version="2.3.1">
         <sequence>
             <module name="Magento_Backend"/>
             <module name="Magento_Config"/>

--- a/view/adminhtml/templates/system/config/trunkrs.phtml
+++ b/view/adminhtml/templates/system/config/trunkrs.phtml
@@ -31,7 +31,7 @@ echo "<div id='trunkrs-app'></div>";
             'browserInfo' => $_SERVER['HTTP_USER_AGENT'],
             'phpVersion' => phpversion(),
             'phpExtensions' => get_loaded_extensions(),
-            'pluginVersion' => 'v2.3.0'
+            'pluginVersion' => 'v2.3.1'
         ],
         'disableAutoShipment' => $block->getDisableAutoShipment()
     ]);

--- a/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/view/adminhtml/ui_component/sales_order_grid.xml
@@ -6,7 +6,7 @@
                 <settings>
                     <url path="trunkrs/order/printLabelAndPackingSlips"/>
                     <type>trunkrs_print_shipping_label_and_packing_slips</type>
-                    <label translate="true">Trunkrs - Print packing slip &amp; shipping Label</label>
+                    <label translate="true">Trunkrs - Print packing slip &amp; shipping label</label>
                 </settings>
             </action>
         </massaction>


### PR DESCRIPTION
- display error message when no shipment found on printing / downloading shipments label 